### PR TITLE
Disconnect from Launchpad before closing app

### DIFF
--- a/window.py
+++ b/window.py
@@ -737,6 +737,7 @@ def make():
 def close():
     global root_destroyed
     app.modified_layout_save_prompt()
+    app.disconnect_lp()
     if not root_destroyed:
         root.destroy()
         root_destroyed = True


### PR DESCRIPTION
This change eliminates bad pointer errors and exceptions from pygame (used by launchpad-py) library. Also new Launchpad MK3 and LPX (we're working on it https://github.com/FMMT666/launchpad.py/pull/48) must go back to custom modes before closing connection. Otherwise they will stuck on programmer mode (programmer mode lock down long pressing session button) on exit and needs to be power cycled to go back to other modes.
Without disconnect:
![without disconnect](https://user-images.githubusercontent.com/10081908/79326472-8e82c200-7f1b-11ea-9ce5-b893e0a6933c.PNG)
With disconnect:
![with disconnect](https://user-images.githubusercontent.com/10081908/79326529-a5c1af80-7f1b-11ea-9883-4b4772a451e4.PNG)
