### PR TITLE
Add load layout on startup functionality

### DIFF
--- a/LPHK.py
+++ b/LPHK.py
@@ -87,19 +87,45 @@ import lp_events, scripts, kb, files, sound, window
 lp = launchpad.Launchpad()
 
 EXIT_ON_WINDOW_CLOSE = True
+LOAD_ON_STARTUP = None
+
 def init():
     global EXIT_ON_WINDOW_CLOSE
+    global LOAD_ON_STARTUP
     if len(sys.argv) > 1:
         if ("--debug" in sys.argv) or ("-d" in sys.argv):
             EXIT_ON_WINDOW_CLOSE = False
             print("[LPHK] Debugging mode active! Will not shut down on window close.")
             print("[LPHK] Run shutdown() to manually close the program correctly.")
+        if "--open" in sys.argv:
+            try:
+                LOAD_ON_STARTUP = sys.argv[sys.argv.index("--open") + 1]
+                if not os.path.exists(LOAD_ON_STARTUP):
+                    LOAD_ON_STARTUP = None
+                    print("[LPHK] File not found!")
+            except:
+                print("[LPHK] File is missing (--open)")
+        if "-o" in sys.argv:
+            try:
+                LOAD_ON_STARTUP = sys.argv[sys.argv.index("-o") + 1]
+                if not os.path.exists(LOAD_ON_STARTUP):
+                    LOAD_ON_STARTUP = None
+                    print("[LPHK] File not found!")
+            except:
+                print("[LPHK] File is missing (-o)")
 
         else:
             print("[LPHK] Invalid argument: " + sys.argv[1] + ". Ignoring...")
     
     files.init(USER_PATH)
     sound.init(USER_PATH)
+
+    # If user not used -o or --open option
+    if LOAD_ON_STARTUP == None:
+        # Check default file exists
+        LOAD_ON_STARTUP = os.path.join(files.LAYOUT_PATH + "\\default.lpl")
+        if not os.path.exists(LOAD_ON_STARTUP):
+            LOAD_ON_STARTUP = None
 
 def shutdown():
     if lp_events.timer != None:
@@ -124,7 +150,7 @@ def shutdown():
 
 def main():
     init()
-    window.init(lp, launchpad, PATH, PROG_PATH, USER_PATH, VERSION, PLATFORM)
+    window.init(lp, launchpad, PATH, PROG_PATH, USER_PATH, VERSION, PLATFORM, LOAD_ON_STARTUP)
     if EXIT_ON_WINDOW_CLOSE:
         shutdown()
 

--- a/window.py
+++ b/window.py
@@ -28,7 +28,7 @@ DICER_NAME = "dicer"
 PATH = None
 PROG_PATH = None
 USER_PATH = None
-
+LOAD_ON_STARTUP = None
 VERSION = None
 
 PLATFORM = None
@@ -54,7 +54,7 @@ lp_connected = False
 lp_mode = None
 colors_to_set = [[DEFAULT_COLOR for y in range(9)] for x in range(9)]
 
-def init(lp_object_in, launchpad_in, path_in, prog_path_in, user_path_in, version_in, platform_in):
+def init(lp_object_in, launchpad_in, path_in, prog_path_in, user_path_in, version_in, platform_in, load_on_startup):
     global lp_object
     global launchpad
     global PATH
@@ -63,6 +63,7 @@ def init(lp_object_in, launchpad_in, path_in, prog_path_in, user_path_in, versio
     global VERSION
     global PLATFORM
     global MAIN_ICON
+    global LOAD_ON_STARTUP
     lp_object = lp_object_in
     launchpad = launchpad_in
     PATH = path_in
@@ -70,6 +71,7 @@ def init(lp_object_in, launchpad_in, path_in, prog_path_in, user_path_in, versio
     USER_PATH = user_path_in
     VERSION = version_in
     PLATFORM = platform_in
+    LOAD_ON_STARTUP = load_on_startup
     
     if PLATFORM == "windows":
         MAIN_ICON = os.path.join(PATH, "resources", "LPHK.ico")
@@ -224,6 +226,8 @@ class Main_Window(tk.Frame):
                 raise Exception()
         except:
             self.popup_choice(self, "No Launchpad Detected...", self.error_image, "Could not detect any connected Launchpads!\nDisconnect and reconnect your USB cable,\nthen click 'Redetect Now'.", [["Ignore", None], ["Redetect Now", self.redetect_lp]])
+        if LOAD_ON_STARTUP != None:
+            files.load_layout_to_lp(LOAD_ON_STARTUP)
 
     def disconnect_lp(self):
         global lp_connected


### PR DESCRIPTION
This changes adds two new command line options to LPHK (-o and --open) which loads layout from its argument at startup (if exist). If both of the options are not used, LPHK will check default.lpl file (in user_layouts folder) and load this file on startup. If none of them exists LPHK will start without any layout loaded.
This options can replaced if startup config file functionality (currently on TODO list) implemented.