### PR TITLE
Change Mk3 pads mode back to live before closing connection

### DIFF
--- a/INSTALL/requirements.txt
+++ b/INSTALL/requirements.txt
@@ -1,5 +1,5 @@
 MouseInfo==0.1.3
-Pillow==7.1.1
+Pillow==8.1.1
 py-getch==1.0.1
 PyAutoGUI==0.9.50
 pygame==1.9.6

--- a/utils/launchpad_connector.py
+++ b/utils/launchpad_connector.py
@@ -76,4 +76,9 @@ def connect(pad):
 
 
 def disconnect(pad):
+    mode = get_mode(pad)
+    
+    if mode == "Mk3":
+        pad.LedSetMode(0)
+    
     pad.Close()


### PR DESCRIPTION
Mk3 pads will stuck in programmers mode if we not set it to live mode before closing connection. launchpad.py do this for Mk3 Pro but (somehow) not for LPX or MiniMk3.