### PR TITLE
Change Mk3 pads mode back to live before closing connection

### DIFF
--- a/utils/launchpad_connector.py
+++ b/utils/launchpad_connector.py
@@ -76,4 +76,9 @@ def connect(pad):
 
 
 def disconnect(pad):
+    mode = get_mode(pad)
+    
+    if mode == "Mk3":
+        pad.LedSetMode(0)
+    
     pad.Close()


### PR DESCRIPTION
Mk3 pads will stuck in programmers mode if we not set it to live mode before closing connection. launchpad.py do this for Mk3 Pro but (somehow) not for LPX or MiniMk3. 
This PR is same as #87 but moved from master to develop branch.