### PR TITLE
Change to https git, bump pygame requirement

### DIFF
--- a/INSTALL/environment-build.yml
+++ b/INSTALL/environment-build.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - tk
   - pip:
-    - git+git://github.com/FMMT666/launchpad.py.git@master
+    - git+https://github.com/FMMT666/launchpad.py.git@master
     - pillow
     - pygame
     - pynput

--- a/INSTALL/environment.yml
+++ b/INSTALL/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - pip
   - tk
   - pip:
-    - git+git://github.com/FMMT666/launchpad.py.git@master
+    - git+https://github.com/FMMT666/launchpad.py.git@master
     - pillow
     - pygame
     - pynput

--- a/INSTALL/requirements.txt
+++ b/INSTALL/requirements.txt
@@ -2,7 +2,7 @@ MouseInfo==0.1.3
 Pillow==8.2.0
 py-getch==1.0.1
 PyAutoGUI==0.9.50
-pygame==2.0.1
+pygame==2.1.2
 PyGetWindow==0.0.8
 PyMsgBox==1.0.7
 pynput==1.6.8
@@ -14,4 +14,4 @@ python3-xlib==0.15
 PyTweening==1.0.3
 six==1.14.0
 tkcolorpicker==2.1.3
--e git+git://github.com/FMMT666/launchpad.py.git@master#egg=launchpad-py
+-e git+https://github.com/FMMT666/launchpad.py.git@master#egg=launchpad-py


### PR DESCRIPTION
This PR brings two fixes:

- Change git to https since unencrypted connection is now disabled and breaks installation: https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git
- Bump PyGame to 2.1.2 which fixes unmet dependencies error on latest Python