### PR TITLE
added startup file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ I have specifically chosen to do my best to develop this using as many cross pla
         * If the second button is already bound, you will get a dialog box with options.
 * Go to `Layout > Save layout as...` to save your current layout for future use, colors and all.
 * Go to `Layout > Load layout...` to load an existing layout. Examples are in `user_layouts/examples/`.
+* (Optional) Create a layout with the name `startup.lpl` that will be automatically loaded every time LPHK starts up.
 
 #### The whole GUI is still rough around the edges, so don't be too surprised if something breaks. If it does, kindly open a detailed issue on GitHub so I can fix the error. :) And don't feel shy making feature requests, either!
 

--- a/window.py
+++ b/window.py
@@ -206,6 +206,9 @@ class Main_Window(tk.Frame):
             self.enable_menu("Layout")
             self.stat["text"] = f"Connected to {lpcon.get_display_name(lp)}"
             self.stat["bg"] = STAT_ACTIVE_COLOR
+            # search for a startup layout and load it
+            if os.path.isfile(os.path.join(files.LAYOUT_PATH, "startup.lpl")):
+                files.load_layout_to_lp(os.path.join(files.LAYOUT_PATH, "startup.lpl"))
 
     def disconnect_lp(self):
         global lp_connected


### PR DESCRIPTION
This adds support for a "startup.lpl" file that is automatically loaded onto the launchpad when LPHK starts up.

It simply scans for this file and tries to load it. If it doesn't exist, the program ignores it and moves on.

All previous functionality still works. I just got tired of physically clicking load layout and selecting my file every time I ran this program. This works really well with the @LOAD_LAYOUT header because you can reference all of your layouts from the launchpad without having to search for them in the folder.